### PR TITLE
Fix real-time hyphenation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In the digital age, secure communication is paramount. Many messaging platforms 
 
 * Create and Join Chats: Users should be able to create new chat sessions with unique encryption keys or join existing ones using these keys.
 
-* Real-Time Messaging: Users should be able to send and receive messages in real time.
+* Real-Time Messaging: Users should be able to send and receive messages in **real-time**.
 
 * Message Encryption: Messages should be encrypted before being stored in the database and decrypted when retrieved to ensure privacy and security.
 


### PR DESCRIPTION
## Summary
- correct hyphenation for real-time in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f6c5748088322a8dabe3b79c5af9a